### PR TITLE
Updated emptyline() -handle"ENTER"

### DIFF
--- a/console.py
+++ b/console.py
@@ -22,9 +22,13 @@ class HBNBCommand(cmd.Cmd):
         "BaseModel", "Amenity", "City", "Place", "Review", "State", "User"
     }
 
-    def do_emptyline(self):
+    def emptyline(self):
         """Do nothing when an empty line is entered"""
-        return True
+        pass
+
+    # def do_emptyline(self):
+    #     """Do nothing when an empty line is entered"""
+    #     return True
 
     def do_quit(self, arg):
         """Exit the program"""


### PR DESCRIPTION
Overridden the default Emptyline method to avoid reprinting the last command whenever an empty string or ENTER is pressed.